### PR TITLE
fix id generator

### DIFF
--- a/common/EndpointEncoding.go
+++ b/common/EndpointEncoding.go
@@ -65,12 +65,11 @@ func (e *Encoding) ToDynamoDB() map[string]ddbtypes.AttributeValue {
 GenerateNumericId generates a (theoretically) unique numeric ID
 */
 func GenerateNumericId() int32 {
-	content, err := GenerateUuidBytes()
+	randId, err := rand.CryptoRandInt63n(99999)
 	if err != nil {
-		log.Fatal("Could not get uuid bytes: ", err)
+		log.Fatal("Could not generate random number")
 	}
-	intval, _ := binary.Uvarint(content[0:8])
-	return int32(intval) + 9900000
+	return int32(randId) + 9900000
 }
 
 /*

--- a/common/EndpointEncoding.go
+++ b/common/EndpointEncoding.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/elastictranscoder/types"

--- a/test_uuid/main.go
+++ b/test_uuid/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/guardian/simple-interactive-deliverables/common"
+)
+
+func main() {
+	numericIdList := make([]int32, 100)
+	for i := 0; i < 100; i++ {
+		//println(common.GenerateStringId())
+		//fmt.Printf("%d\n", common.GenerateNumericId())
+		numericIdList[i] = common.GenerateNumericId()
+	}
+
+	sort.Slice(numericIdList, func(a, b int) bool {
+		return numericIdList[a] < numericIdList[b]
+	})
+
+	for _, v := range numericIdList {
+		fmt.Printf("%d\n", v)
+	}
+}

--- a/test_uuid/main.go
+++ b/test_uuid/main.go
@@ -10,8 +10,6 @@ import (
 func main() {
 	numericIdList := make([]int32, 100)
 	for i := 0; i < 100; i++ {
-		//println(common.GenerateStringId())
-		//fmt.Printf("%d\n", common.GenerateNumericId())
 		numericIdList[i] = common.GenerateNumericId()
 	}
 


### PR DESCRIPTION
## What does this change?

We noticed that GenerateNumericalId was occasionally returning ids that collided with existing records. By using `rand.CryptoRandInt63n` the ids appear to be much more random.

A future improvement would be to check if an id exists by hitting the endpoint, checking for a 200/404 and creating a new id if necessary. 

